### PR TITLE
shortened code about 400 bytes by change dlist_ptr[] to POKEs()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,6 @@
 Context context;
 
 extern unsigned char* video_ptr;
-extern unsigned char* dlist_ptr;
 extern unsigned short screen_memory;
 extern unsigned char* font_ptr;
 
@@ -111,7 +110,6 @@ void setup(Context *context)
   OS.sdmctl=0; // Turn off screen
   memcpy((void *)DISPLAY_LIST,&config_dlist,sizeof(config_dlist)); // copy display list to $0600
   OS.sdlst=(void *)DISPLAY_LIST;                     // and use it.
-  dlist_ptr=(unsigned char *)OS.sdlst;               // Set up the vars for the screen output macros
   screen_memory=PEEKW(560)+4;
   video_ptr=(unsigned char*)(PEEKW(screen_memory));
 

--- a/src/mount_and_boot.c
+++ b/src/mount_and_boot.c
@@ -13,7 +13,7 @@
 #include "die.h"
 
 char text_mounting_host_slot_X[]="MOUNTING HOST SLOT X";
-char text_mounting_device_slot_X[]="MOUNTING DEV SLOT X";
+char text_mounting_device_slot_X[]="MOUNTING DEV SLOT X ";
 char text_booting[]="SUCCESSFUL! BOOTING ";
 
 /**

--- a/src/screen.c
+++ b/src/screen.c
@@ -7,10 +7,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <conio.h>
+#include <peekpoke.h>
 #include "screen.h"
 
 unsigned char* video_ptr;
-unsigned char* dlist_ptr;
 unsigned short screen_memory;
 unsigned char* font_ptr;
 
@@ -27,7 +27,7 @@ void screen_clear_line(unsigned char y)
 /**
  * Print ATASCII string to display memory
  */
-void screen_puts(unsigned char x,unsigned char y,char *s)
+void screen_puts(unsigned char x, unsigned char y, char *s)
 {
   char offset;
   
@@ -131,12 +131,14 @@ void screen_print_ip(unsigned char x, unsigned char y, unsigned char *buf)
 /**
  * Special hex output of numbers under 16, e.g. 9 -> 09, 10 -> 0A
  */
-void itoa_hex(int val, char *buf)
+void itoa_hex(unsigned char val, char *buf)
 {
+
   if (val < 16) {
     *(buf++) = '0';
   }
   itoa(val, buf, 16);
+
 }
 
 /**
@@ -163,8 +165,12 @@ void screen_print_mac(unsigned char x, unsigned char y, unsigned char *buf)
  */
 void screen_dlist_diskulator_hosts(void)
 {
-  dlist_ptr[0x0F] = dlist_ptr[0x10] = 6;
-  dlist_ptr[0x0A] = dlist_ptr[0x0B] = dlist_ptr[0x1B] = dlist_ptr[0x1C] = 2;
+  POKE(DISPLAY_LIST+0x0f,6);
+  POKE(DISPLAY_LIST+0x10,6);
+  POKE(DISPLAY_LIST+0x0a,2);
+  POKE(DISPLAY_LIST+0x0b,2);
+  POKE(DISPLAY_LIST+0x1b,2);
+  POKE(DISPLAY_LIST+0x1c,2);
 }
 
 /**
@@ -172,9 +178,10 @@ void screen_dlist_diskulator_hosts(void)
  */
 void screen_dlist_diskulator_info(void)
 {
-  dlist_ptr[0x0A] = 7;
-  dlist_ptr[0x0B] = 6;
-  dlist_ptr[0x0F] = dlist_ptr[0x10] = 2;
+  POKE(DISPLAY_LIST+0x0a,7);
+  POKE(DISPLAY_LIST+0x0b,6);
+  POKE(DISPLAY_LIST+0x0f,2);
+  POKE(DISPLAY_LIST+0x10,2);
 }
 
 /**
@@ -182,8 +189,10 @@ void screen_dlist_diskulator_info(void)
  */
 void screen_dlist_wifi(void)
 {
-  dlist_ptr[0x0a] = dlist_ptr[0x0b] = 2;
-  dlist_ptr[0x1b] = dlist_ptr[0x1c] = 6;
+  POKE (DISPLAY_LIST+0x0a,2);
+  POKE (DISPLAY_LIST+0x0b,2);
+  POKE (DISPLAY_LIST+0x1b,6);
+  POKE (DISPLAY_LIST+0x1c,6);
 }
 
 /**
@@ -191,8 +200,8 @@ void screen_dlist_wifi(void)
  */
 void screen_dlist_mount_and_boot(void)
 {
-  dlist_ptr[0x0a] = dlist_ptr[0x0b] = 2;
-  dlist_ptr[0x1b] = dlist_ptr[0x1c] = 6;
+  // the same as above
+  screen_dlist_wifi();
 }
 
 /**
@@ -200,8 +209,10 @@ void screen_dlist_mount_and_boot(void)
  */
 void screen_dlist_diskulator_select(void)
 {
-  dlist_ptr[0x0f] = dlist_ptr[0x10] = 2;
-  dlist_ptr[0x1B] = dlist_ptr[0x1C] = 2;
+  POKE(DISPLAY_LIST+0x0f,2);
+  POKE(DISPLAY_LIST+0x10,2);
+  POKE(DISPLAY_LIST+0x1b,2);
+  POKE(DISPLAY_LIST+0x1c,2);
 }
 
 /**
@@ -209,8 +220,7 @@ void screen_dlist_diskulator_select(void)
  */
 void screen_dlist_diskulator_select_aux(void)
 {
-  dlist_ptr[0x0f] = dlist_ptr[0x10] = 2;
-  dlist_ptr[0x1B] = dlist_ptr[0x1C] = 2;
+  screen_dlist_diskulator_select();
 }
 
 /**
@@ -218,7 +228,7 @@ void screen_dlist_diskulator_select_aux(void)
  */
 void screen_dlist_diskulator_slot(void)
 {
-  dlist_ptr[0x0f] = dlist_ptr[0x10] = dlist_ptr[0x1B] = dlist_ptr[0x1C] = 2;
+  screen_dlist_diskulator_select();
 }
 
 /**


### PR DESCRIPTION
Throwing away unneccessary vars, making POKE instead od [] access made code over 400 bytes shorter.
Also removed residue after mounted slot display by adding space.