### PR TITLE
typo in comment syntax and add missing semi-colon

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -221,7 +221,6 @@ void screen_print_mac(unsigned char x, unsigned char y, unsigned char *buf)
 }
 /**
  * A set of functions to support custom screen formating to support different sections in the config program.
-/**
  * The Patch the dlist for the hosts screen
  */
 void screen_dlist_diskulator_hosts(void)

--- a/src/screen.c
+++ b/src/screen.c
@@ -15,7 +15,7 @@
  #include "screen.h"        // Local header file for the screen defines 
 
  unsigned char* video_ptr;  // a pointer to the memory address containing the screen contents
- unsigned char* cursor_ptr  // a pointer to the current cursor position on the screen
+ unsigned char* cursor_ptr;  // a pointer to the current cursor position on the screen
 
  // Setup the screen display dimensions for the program to be able to draw items on the screen
 void config_dlist=


### PR DESCRIPTION
It now compiles.  I knew I should have tried to compile it before I did the PR.  Sorry for the confusion.

make                                                              
cl65 -t atari -c --create-dep obj/atari/screen.d -Os -o obj/atari/screen.o src/screen.c
cl65 -t atari -c --create-dep obj/atari/set_wifi.d -Os -o obj/atari/set_wifi.o src/set_wifi.c
cl65 -t atari -c --create-dep obj/atari/state.d -Os -o obj/atari/state.o src/state.c
cl65 -t atari -c --create-dep obj/atari/bar-setup-regs.d  -o obj/atari/bar-setup-regs.o src/bar-setup-regs.s
cl65 -t atari -c --create-dep obj/atari/crt0.d  -o obj/atari/crt0.o src/crt0.s
cl65 -t atari -c --create-dep obj/atari/sio.d  -o obj/atari/sio.o src/sio.s
cl65 -t atari --mapfile config.map -o config.com -C src/atari.cfg obj/atari/bar.o obj/atari/connect_wifi.o obj/atari/die.o obj/atari/diskulator_copy.o obj/atari/diskulator_hosts.o obj/atari/diskulator_info.o obj/atari/diskulator_select.o obj/atari/diskulator_slot.o obj/atari/error.o obj/atari/font.o obj/atari/fuji_sio.o obj/atari/input.o obj/atari/main.o obj/atari/mount_and_boot.o obj/atari/screen.o obj/atari/set_wifi.o obj/atari/state.o obj/atari/bar-setup-regs.o obj/atari/crt0.o obj/atari/sio.o