### PR TITLE
Makefile fix due to fujinet-config-tools moving things into an 'atari' subdirectory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,8 +318,8 @@ test: $(PROGRAM)
 
 dist: $(PROGRAM)
 	mkdir -p dist
-	cp ../fujinet-config-tools/dist/*.COM dist/ || true
-	cp ../fujinet-config-tools/dist/*.com dist/ || true
+	cp ../fujinet-config-tools/atari/dist/*.COM dist/ || true
+	cp ../fujinet-config-tools/atari/dist/*.com dist/ || true
 	cp $(PROGRAM) dist/
 	dir2atr -m -S -B picoboot.bin autorun.atr dist/
 


### PR DESCRIPTION
Copy the files from the new "atari" subdirectory in fujinet-config-tools.